### PR TITLE
Extract directly from the download stream

### DIFF
--- a/LANCommander.Playnite.Extension/InstallController.cs
+++ b/LANCommander.Playnite.Extension/InstallController.cs
@@ -102,25 +102,35 @@ namespace LANCommander.PlaynitePlugin
 
             Plugin.PlayniteApi.Dialogs.ActivateGlobalProgress(progress =>
             {
-                Directory.CreateDirectory(destination);
-                progress.ProgressMaxValue = 100;
-                progress.CurrentProgressValue = 0;
-
-                using (var gameStream = Plugin.LANCommander.StreamGame(game.Id))
-                using (var reader = ReaderFactory.Open(gameStream))
+                try
                 {
-                    progress.ProgressMaxValue = gameStream.Length;
+                    Directory.CreateDirectory(destination);
+                    progress.ProgressMaxValue = 100;
+                    progress.CurrentProgressValue = 0;
 
-                    gameStream.OnProgress += (pos, len) =>
+                    using (var gameStream = Plugin.LANCommander.StreamGame(game.Id))
+                    using (var reader = ReaderFactory.Open(gameStream))
                     {
-                        progress.CurrentProgressValue = pos;
-                    };
+                        progress.ProgressMaxValue = gameStream.Length;
 
-                    reader.WriteAllToDirectory(destination, new ExtractionOptions()
+                        gameStream.OnProgress += (pos, len) =>
+                        {
+                            progress.CurrentProgressValue = pos;
+                        };
+
+                        reader.WriteAllToDirectory(destination, new ExtractionOptions()
+                        {
+                            ExtractFullPath = true,
+                            Overwrite = true
+                        });
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (Directory.Exists(destination))
                     {
-                        ExtractFullPath = true,
-                        Overwrite = true
-                    });
+                        Directory.Delete(destination, true);
+                    }
                 }
             },
             new GlobalProgressOptions($"Downloading {game.Title}...")

--- a/LANCommander.Playnite.Extension/LANCommander.PlaynitePlugin.csproj
+++ b/LANCommander.Playnite.Extension/LANCommander.PlaynitePlugin.csproj
@@ -34,9 +34,6 @@
     <Reference Include="BeaconLib, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\rix0rrr.BeaconLib.1.0.2\lib\net40\BeaconLib.dll</HintPath>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=1.4.2.13, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpZipLib.1.4.2\lib\netstandard2.0\ICSharpCode.SharpZipLib.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
@@ -47,6 +44,9 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="RestSharp, Version=106.15.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.15.0\lib\net452\RestSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpCompress, Version=0.33.0.0, Culture=neutral, PublicKeyToken=afb0a02973931d96, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpCompress.0.33.0\lib\net462\SharpCompress.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
@@ -64,8 +64,11 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encoding.CodePages, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encoding.CodePages.7.0.0\lib\net462\System.Text.Encoding.CodePages.dll</HintPath>
     </Reference>
     <Reference Include="System.Text.Encodings.Web, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Text.Encodings.Web.5.0.0\lib\net461\System.Text.Encodings.Web.dll</HintPath>
@@ -93,6 +96,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TrackableStream.cs" />
     <Compile Include="Extensions\MultiplayerInfoExtensions.cs" />
     <Compile Include="Helpers\RetryHelper.cs" />
     <Compile Include="PowerShellRuntime.cs" />

--- a/LANCommander.Playnite.Extension/LANCommanderClient.cs
+++ b/LANCommander.Playnite.Extension/LANCommanderClient.cs
@@ -1,7 +1,6 @@
 ﻿using LANCommander.SDK;
 using LANCommander.SDK.Models;
 using RestSharp;
-using RestSharp.Extensions;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -9,10 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
-using System.Text;
 using System.Threading.Tasks;
-using System.Windows.Media.Converters;
-using YamlDotNet.Core;
 
 namespace LANCommander.PlaynitePlugin
 {
@@ -62,6 +58,20 @@ namespace LANCommander.PlaynitePlugin
             client.DownloadFileAsync(new Uri($"{Client.BaseUrl}{route}"), tempFile);
 
             return tempFile;
+        }
+
+        private TrackableStream StreamRequest(string route)
+        {
+            route = route.TrimStart('/');
+
+            var client = new WebClient();
+            var tempFile = Path.GetTempFileName();
+
+            client.Headers.Add("Authorization", $"Bearer {Token.AccessToken}");
+
+            var ws = client.OpenRead(new Uri($"{Client.BaseUrl}{route}"));
+
+            return new TrackableStream(ws, true, Convert.ToInt64(client.ResponseHeaders["Content-Length"]));
         }
 
         public async Task<AuthResponse> AuthenticateAsync(string username, string password)
@@ -164,6 +174,11 @@ namespace LANCommander.PlaynitePlugin
         public string DownloadGame(Guid id, Action<DownloadProgressChangedEventArgs> progressHandler, Action<AsyncCompletedEventArgs> completeHandler)
         {
             return DownloadRequest($"/api/Games/{id}/Download", progressHandler, completeHandler);
+        }
+
+        public TrackableStream StreamGame(Guid id)
+        {
+            return StreamRequest($"/api/Games/{id}/Download");
         }
 
         public string DownloadArchive(Guid id, Action<DownloadProgressChangedEventArgs> progressHandler, Action<AsyncCompletedEventArgs> completeHandler)

--- a/LANCommander.Playnite.Extension/LANCommanderLibraryPlugin.cs
+++ b/LANCommander.Playnite.Extension/LANCommanderLibraryPlugin.cs
@@ -1,28 +1,17 @@
-﻿using ICSharpCode.SharpZipLib.Core;
-using ICSharpCode.SharpZipLib.Zip;
-using LANCommander.PlaynitePlugin.Extensions;
+﻿using LANCommander.PlaynitePlugin.Extensions;
 using LANCommander.PlaynitePlugin.Services;
-using LANCommander.SDK;
 using Playnite.SDK;
 using Playnite.SDK.Events;
 using Playnite.SDK.Models;
 using Playnite.SDK.Plugins;
 using System;
-using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net.NetworkInformation;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
 using System.Windows.Media;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 using PN = Playnite;
 
 namespace LANCommander.PlaynitePlugin
@@ -294,9 +283,10 @@ namespace LANCommander.PlaynitePlugin
                     FontSize = 16,
                     FontFamily = ResourceProvider.GetResource("FontIcoFont") as FontFamily,
                     Padding = new Thickness(10, 0, 10, 0),
-                    
+
                 },
-                Activated = () => {
+                Activated = () =>
+                {
                     ShowNameChangeWindow();
                 }
             };

--- a/LANCommander.Playnite.Extension/TrackableStream.cs
+++ b/LANCommander.Playnite.Extension/TrackableStream.cs
@@ -1,0 +1,325 @@
+﻿using System.IO;
+
+namespace LANCommander.PlaynitePlugin
+{
+    internal class TrackableStream : MemoryStream
+    {
+        public delegate void OnProgressDelegate(long Position, long Length);
+        public event OnProgressDelegate OnProgress = delegate { };
+        private long internalStreamProgress = 0;
+        private Stream internalStream;
+
+        //
+        // Summary:
+        //     Initializes a new instance of the TrackableStream class with an expandable
+        //     capacity initialized to zero.
+        public TrackableStream() : base() { }
+
+        //
+        // Summary:
+        //     Initializes a new instance of the TrackableStream class with the contents of stream.
+        //     capacity initialized to zero.
+        public TrackableStream(Stream stream) : base()
+        {
+            internalStream = stream;
+        }
+
+        //
+        // Summary:
+        //     Initializes a new instance of the TrackableStream class with an expandable
+        //     capacity initialized as specified.
+        //
+        // Parameters:
+        //   capacity:
+        //     The initial size of the internal array in bytes.
+        //
+        // Exceptions:
+        //   T:System.ArgumentOutOfRangeException:
+        //     capacity is negative.
+        public TrackableStream(int capacity) : base(capacity) { }
+
+        //
+        // Summary:
+        //     Initializes a new non-resizable instance of the TrackableStream class
+        //     based on the specified byte array.
+        //
+        // Parameters:
+        //   buffer:
+        //     The array of unsigned bytes from which to create the current stream.
+        //
+        // Exceptions:
+        //   T:System.ArgumentNullException:
+        //     buffer is null.
+        public TrackableStream(byte[] buffer) : base(buffer) { }
+
+        //
+        // Summary:
+        //     Initializes a new non-resizable instance of the TrackableStream class
+        //     based on the specified byte array with the TrackableStream.CanWrite property
+        //     set as specified.
+        //
+        // Parameters:
+        //   buffer:
+        //     The array of unsigned bytes from which to create this stream.
+        //
+        //   writable:
+        //     The setting of the TrackableStream.CanWrite property, which determines
+        //     whether the stream supports writing.
+        //
+        // Exceptions:
+        //   T:System.ArgumentNullException:
+        //     buffer is null.
+        public TrackableStream(byte[] buffer, bool writable) : base(buffer, writable) { }
+
+        //
+        // Summary:
+        //     Initializes a new non-resizable instance of the TrackableStream class
+        //     based on the specified region (index) of a byte array.
+        //
+        // Parameters:
+        //   buffer:
+        //     The array of unsigned bytes from which to create this stream.
+        //
+        //   index:
+        //     The index into buffer at which the stream begins.
+        //
+        //   count:
+        //     The length of the stream in bytes.
+        //
+        // Exceptions:
+        //   T:System.ArgumentNullException:
+        //     buffer is null.
+        //
+        //   T:System.ArgumentOutOfRangeException:
+        //     index or count is less than zero.
+        //
+        //   T:System.ArgumentException:
+        //     The buffer length minus index is less than count.
+        public TrackableStream(byte[] buffer, int index, int count) : base(buffer, index, count) { }
+
+        //
+        // Summary:
+        //     Initializes a new non-resizable instance of the TrackableStream class
+        //     based on the specified region of a byte array, with the TrackableStream.CanWrite
+        //     property set as specified.
+        //
+        // Parameters:
+        //   buffer:
+        //     The array of unsigned bytes from which to create this stream.
+        //
+        //   index:
+        //     The index in buffer at which the stream begins.
+        //
+        //   count:
+        //     The length of the stream in bytes.
+        //
+        //   writable:
+        //     The setting of the TrackableStream.CanWrite property, which determines
+        //     whether the stream supports writing.
+        //
+        // Exceptions:
+        //   T:System.ArgumentNullException:
+        //     buffer is null.
+        //
+        //   T:System.ArgumentOutOfRangeException:
+        //     index or count are negative.
+        //
+        //   T:System.ArgumentException:
+        //     The buffer length minus index is less than count.
+        public TrackableStream(byte[] buffer, int index, int count, bool writable) : base(buffer, index, count, writable) { }
+
+        //
+        // Summary:
+        //     Initializes a new instance of the TrackableStream class based on the specified
+        //     region of a byte array, with the TrackableStream.CanWrite property set
+        //     as specified, and the ability to call TrackableStream.GetBuffer set as
+        //     specified.
+        //
+        // Parameters:
+        //   buffer:
+        //     The array of unsigned bytes from which to create this stream.
+        //
+        //   index:
+        //     The index into buffer at which the stream begins.
+        //
+        //   count:
+        //     The length of the stream in bytes.
+        //
+        //   writable:
+        //     The setting of the TrackableStream.CanWrite property, which determines
+        //     whether the stream supports writing.
+        //
+        //   publiclyVisible:
+        //     true to enable TrackableStream.GetBuffer, which returns the unsigned byte
+        //     array from which the stream was created; otherwise, false.
+        //
+        // Exceptions:
+        //   T:System.ArgumentNullException:
+        //     buffer is null.
+        //
+        //   T:System.ArgumentOutOfRangeException:
+        //     index or count is negative.
+        //
+        //   T:System.ArgumentException:
+        //     The buffer length minus index is less than count.
+        public TrackableStream(byte[] buffer, int index, int count, bool writable, bool publiclyVisible) : base(buffer, index, count, writable, publiclyVisible) { }
+
+        //
+        // Summary:
+        //     Writes a block of bytes to the current stream using data read from a buffer.
+        //
+        // Parameters:
+        //   buffer:
+        //     The buffer to write data from.
+        //
+        //   offset:
+        //     The zero-based byte offset in buffer at which to begin copying bytes to the current
+        //     stream.
+        //
+        //   count:
+        //     The maximum number of bytes to write.
+        //
+        // Exceptions:
+        //   T:System.ArgumentNullException:
+        //     buffer is null.
+        //
+        //   T:System.NotSupportedException:
+        //     The stream does not support writing. For additional information see System.IO.Stream.CanWrite.-or-
+        //     The current position is closer than count bytes to the end of the stream, and
+        //     the capacity cannot be modified.
+        //
+        //   T:System.ArgumentException:
+        //     offset subtracted from the buffer length is less than count.
+        //
+        //   T:System.ArgumentOutOfRangeException:
+        //     offset or count are negative.
+        //
+        //   T:System.IO.IOException:
+        //     An I/O error occurs.
+        //
+        //   T:System.ObjectDisposedException:
+        //     The current stream instance is closed.
+        public override void Write(byte[] array, int offset, int count)
+        {
+            if (internalStream is Stream)
+            {
+                internalStream.Write(array, offset, count);
+                OnProgress(internalStream.Position, internalStream.Length);
+            }
+            else
+            {
+                base.Write(array, offset, count);
+                OnProgress(this.Position, this.Length);
+            }
+        }
+
+        //
+        // Summary:
+        //     Writes a byte to the current stream at the current position.
+        //
+        // Parameters:
+        //   value:
+        //     The byte to write.
+        //
+        // Exceptions:
+        //   T:System.NotSupportedException:
+        //     The stream does not support writing. For additional information see System.IO.Stream.CanWrite.-or-
+        //     The current position is at the end of the stream, and the capacity cannot be
+        //     modified.
+        //
+        //   T:System.ObjectDisposedException:
+        //     The current stream is closed.
+        public override void WriteByte(byte value)
+        {
+            if (internalStream is Stream)
+            {
+                internalStream.WriteByte(value);
+                OnProgress(internalStream.Position, internalStream.Length);
+            }
+            else
+            {
+                base.WriteByte(value);
+                OnProgress(this.Position, this.Length);
+            }
+        }
+
+        //
+        // Summary:
+        //     Reads a block of bytes from the current stream and writes the data to a buffer.
+        //
+        // Parameters:
+        //   buffer:
+        //     When this method returns, contains the specified byte array with the values between
+        //     offset and (offset + count - 1) replaced by the characters read from the current
+        //     stream.
+        //
+        //   offset:
+        //     The zero-based byte offset in buffer at which to begin storing data from the
+        //     current stream.
+        //
+        //   count:
+        //     The maximum number of bytes to read.
+        //
+        // Returns:
+        //     The total number of bytes written into the buffer. This can be less than the
+        //     number of bytes requested if that number of bytes are not currently available,
+        //     or zero if the end of the stream is reached before any bytes are read.
+        //
+        // Exceptions:
+        //   T:System.ArgumentNullException:
+        //     buffer is null.
+        //
+        //   T:System.ArgumentOutOfRangeException:
+        //     offset or count is negative.
+        //
+        //   T:System.ArgumentException:
+        //     offset subtracted from the buffer length is less than count.
+        //
+        //   T:System.ObjectDisposedException:
+        //     The current stream instance is closed.
+        public override int Read(byte[] array, int offset, int count)
+        {
+            int r;
+            if (internalStream is Stream)
+            {
+                r = internalStream.Read(array, offset, count);
+                internalStreamProgress += r;
+                OnProgress(internalStreamProgress, this.Length);
+            }
+            else
+            {
+                r = base.Read(array, offset, count);
+                OnProgress(this.Position, this.Length);
+            }
+
+            return r;
+        }
+
+        //
+        // Summary:
+        //     Reads a byte from the current stream.
+        //
+        // Returns:
+        //     The byte cast to a System.Int32, or -1 if the end of the stream has been reached.
+        //
+        // Exceptions:
+        //   T:System.ObjectDisposedException:
+        //     The current stream instance is closed.
+        public override int ReadByte()
+        {
+            int r;
+            if (internalStream is Stream)
+            {
+                r = internalStream.ReadByte();
+                internalStreamProgress += r;
+                OnProgress(internalStreamProgress, this.Length);
+            }
+            else
+            {
+                r = base.ReadByte();
+                OnProgress(this.Position, this.Length);
+            }
+            return r;
+        }
+    }
+}

--- a/LANCommander.Playnite.Extension/TrackableStream.cs
+++ b/LANCommander.Playnite.Extension/TrackableStream.cs
@@ -1,13 +1,16 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace LANCommander.PlaynitePlugin
 {
-    internal class TrackableStream : MemoryStream
+    internal class TrackableStream : MemoryStream, IDisposable
     {
         public delegate void OnProgressDelegate(long Position, long Length);
         public event OnProgressDelegate OnProgress = delegate { };
         private long internalStreamProgress = 0;
         private Stream internalStream;
+        private bool disposeStream = false;
+        private long? streamLength;
 
         //
         // Summary:
@@ -19,9 +22,11 @@ namespace LANCommander.PlaynitePlugin
         // Summary:
         //     Initializes a new instance of the TrackableStream class with the contents of stream.
         //     capacity initialized to zero.
-        public TrackableStream(Stream stream) : base()
+        public TrackableStream(Stream stream, bool disposeStream = false, long? streamLength = null) : base()
         {
             internalStream = stream;
+            this.disposeStream = disposeStream;
+            this.streamLength = streamLength;
         }
 
         //
@@ -321,5 +326,15 @@ namespace LANCommander.PlaynitePlugin
             }
             return r;
         }
+
+        public void Dispose()
+        {
+            if (disposeStream)
+            {
+                internalStream.Dispose();
+            }
+        }
+
+        public long Length => streamLength ?? internalStream.Length;
     }
 }

--- a/LANCommander.Playnite.Extension/UninstallController.cs
+++ b/LANCommander.Playnite.Extension/UninstallController.cs
@@ -1,17 +1,8 @@
-﻿using Playnite.SDK;
+﻿using LANCommander.SDK.Enums;
 using Playnite.SDK.Models;
 using Playnite.SDK.Plugins;
-using LANCommander.SDK.Extensions;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using ICSharpCode.SharpZipLib.Zip;
-using ICSharpCode.SharpZipLib.Core;
-using LANCommander.SDK.Enums;
 
 namespace LANCommander.PlaynitePlugin
 {

--- a/LANCommander.Playnite.Extension/app.config
+++ b/LANCommander.Playnite.Extension/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/LANCommander.Playnite.Extension/packages.config
+++ b/LANCommander.Playnite.Extension/packages.config
@@ -6,11 +6,12 @@
   <package id="PowerShellStandard.Library" version="5.1.1" targetFramework="net462" />
   <package id="RestSharp" version="106.15.0" targetFramework="net462" />
   <package id="rix0rrr.BeaconLib" version="1.0.2" targetFramework="net462" />
-  <package id="SharpZipLib" version="1.4.2" targetFramework="net462" />
+  <package id="SharpCompress" version="0.33.0" targetFramework="net462" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
   <package id="System.Memory" version="4.5.5" targetFramework="net462" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net462" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net462" />
+  <package id="System.Text.Encoding.CodePages" version="7.0.0" targetFramework="net462" />
   <package id="System.Text.Encodings.Web" version="5.0.0" targetFramework="net462" />
   <package id="System.Text.Json" version="5.0.1" targetFramework="net462" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net462" />


### PR DESCRIPTION
This PR uses streams and SharpCompress to extract on the fly while downloading instead of saving to disk first and then extracting.